### PR TITLE
fix: resolve import alias issues in tsconfig.json for IDEs and Docker

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,10 +1,23 @@
 {
-  // https://nuxt.com/docs/guide/concepts/typescript
-  "extends": "./.nuxt/tsconfig.json",
   "compilerOptions": {
     "strict": true,
     "skipLibCheck": true,
     "module": "ESNext",
-    "types": ["@vueuse/nuxt", "@vueuse/core", "@pinia/nuxt", "vitest/globals"]
-  }
+    "lib": ["ESNext"],
+    "types": [
+      "@vueuse/nuxt",
+      "@vueuse/core",
+      "@pinia/nuxt",
+      "vitest/globals"
+    ],
+
+    // Required to support @/ or ~/ alias everywhere
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"],
+      "~/*": ["./*"]
+    }
+  },
+  // Ensures all files are included
+  "include": ["./**/*"]
 }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This PR fixes IDE (e.g. Volar) and CI issues related to unresolved import aliases (`@/` and `~/`) in TypeScript.  

Even though the project uses these aliases, TypeScript and Docker builds failed due to missing `baseUrl` and `paths` configuration in `tsconfig.json`.

**This PR adds the following:**
- `"baseUrl": "."` and `"paths"` to `compilerOptions` in `tsconfig.json`
- Ensures that `@/types`, `~/utils`, etc., are resolved correctly
- Fixes import resolution errors in VSCode and CI/Docker environments

### Related issue

- Fixes #19