### PR TITLE
feat(sidebar): improved the transition from the Scribe logo to the Sc…

### DIFF
--- a/frontend/components/sidebar/left/SidebarLeftHeader.vue
+++ b/frontend/components/sidebar/left/SidebarLeftHeader.vue
@@ -17,7 +17,7 @@
         }"
       >
         <IconScribeSidebar
-          class="z-1 absolute inset-0 flex h-6 w-8 flex-shrink-0 items-center justify-center overflow-clip"
+          class="z-1 absolute inset-0 flex h-20 w-8 flex-shrink-0 items-center justify-center overflow-clip"
           :class="{
             hidden:
               sidebar.collapsed == false || sidebar.collapsedSwitch == false,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4791,9 +4791,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001646, caniuse-lite@npm:^1.0.30001688":
-  version: 1.0.30001699
-  resolution: "caniuse-lite@npm:1.0.30001699"
-  checksum: 10c0/e87b3a0602c3124131f6a21f1eb262378e17a2ee3089e3c472ac8b9caa85cf7d6a219655379302c29c6f10a74051f2a712639d7f98ee0444c73fefcbaf25d519
+  version: 1.0.30001735
+  resolution: "caniuse-lite@npm:1.0.30001735"
+  checksum: 10c0/1cb74221f16f8835c903770c1cf88fb73a07298b8398396a2b97570136e8f691053ee5840eb589fe34b4ede14ab828c9421d893a67e43c26ef91ab052813cb8c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
…ribe icon in the docs sidebar header

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
I moved the Scribe icon in the collapsed docs sidebar header lower to avoid overlap with the collapse button and smoothen the transition with the uncollapsed Scribe logo. I tested by running the site via Docker and checking that the UI works. If you view the files changed, you will see frontend/yarn.lock was also changed somehow by my set up process, but this is unrelated to my feature. If the change to yarn.lock is an issue, please let me know!
### Related issue

<!--- Scribe prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #ISSUE_NUMBER 28
